### PR TITLE
Ajout du support des headers dans la query

### DIFF
--- a/CSharp/Domain/CSharpSDK.Domain/CSharpSDK.Domain.csproj
+++ b/CSharp/Domain/CSharpSDK.Domain/CSharpSDK.Domain.csproj
@@ -49,13 +49,11 @@
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NExtends, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NExtends.1.0.3\lib\net451\NExtends.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NExtends, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NExtends.1.0.11\lib\net451\NExtends.dll</HintPath>
     </Reference>
     <Reference Include="RDD.Domain, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RDD.Domain.1.0.10.1\lib\net451\RDD.Domain.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\RDD.Domain.1.1.3\lib\net461\RDD.Domain.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/CSharp/Domain/CSharpSDK.Domain/IApiService.cs
+++ b/CSharp/Domain/CSharpSDK.Domain/IApiService.cs
@@ -1,11 +1,6 @@
 ﻿using RDD.Domain;
 using RDD.Domain.Models.Querying;
-using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Lucca.CSharpSDK.Domain
 {
@@ -13,10 +8,19 @@ namespace Lucca.CSharpSDK.Domain
 		where TEntity : class, IEntityBase
 	{
 		IEnumerable<TEntity> Get(Query<TEntity> query);
+
 		IEnumerable<TEntity> GetAll();
+		IEnumerable<TEntity> GetAll(Query<TEntity> query);
+
 		TEntity GetById(string uri);
+		TEntity GetById(string uri, Query<TEntity> query);
+
 		TEntity Post(TEntity entity);
+		TEntity Post(TEntity entity, Query<TEntity> query);
+
 		IDownloadableEntity PostFile(string uri, string filePath);
+
 		TEntity Put(string uri, TEntity entity);
+		TEntity Put(string uri, TEntity entity, Query<TEntity> query);
 	}
 }

--- a/CSharp/Domain/CSharpSDK.Domain/packages.config
+++ b/CSharp/Domain/CSharpSDK.Domain/packages.config
@@ -3,6 +3,6 @@
   <package id="EntityFramework" version="6.0.2" targetFramework="net461" />
   <package id="LINQKit" version="1.1.2" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net461" />
-  <package id="NExtends" version="1.0.3" targetFramework="net461" />
-  <package id="RDD.Domain" version="1.0.10.1" targetFramework="net461" />
+  <package id="NExtends" version="1.0.11" targetFramework="net461" />
+  <package id="RDD.Domain" version="1.1.3" targetFramework="net461" />
 </packages>

--- a/CSharp/Infra/CSharp.Infra.Tests/CSharpSDK.Infra.Tests.csproj
+++ b/CSharp/Infra/CSharp.Infra.Tests/CSharpSDK.Infra.Tests.csproj
@@ -67,21 +67,18 @@
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NExtends, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NExtends.1.0.3\lib\net451\NExtends.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NExtends, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NExtends.1.0.11\lib\net451\NExtends.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDD.Domain, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RDD.Domain.1.0.10.1\lib\net451\RDD.Domain.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\RDD.Domain.1.1.3\lib\net461\RDD.Domain.dll</HintPath>
     </Reference>
     <Reference Include="RDD.Infra, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RDD.Infra.1.0.10.1\lib\net451\RDD.Infra.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\RDD.Infra.1.1.3\lib\net461\RDD.Infra.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/CSharp/Infra/CSharp.Infra.Tests/packages.config
+++ b/CSharp/Infra/CSharp.Infra.Tests/packages.config
@@ -8,8 +8,8 @@
   <package id="MongoDB.Driver" version="2.2.3" targetFramework="net461" />
   <package id="MongoDB.Driver.Core" version="2.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net461" />
-  <package id="NExtends" version="1.0.3" targetFramework="net461" />
+  <package id="NExtends" version="1.0.11" targetFramework="net461" />
   <package id="NUnit" version="3.0.1" targetFramework="net461" />
-  <package id="RDD.Domain" version="1.0.10.1" targetFramework="net461" />
-  <package id="RDD.Infra" version="1.0.10.1" targetFramework="net461" />
+  <package id="RDD.Domain" version="1.1.3" targetFramework="net461" />
+  <package id="RDD.Infra" version="1.1.3" targetFramework="net461" />
 </packages>

--- a/CSharp/Infra/CSharpSDK.Infra/CSharpSDK.Infra.csproj
+++ b/CSharp/Infra/CSharpSDK.Infra/CSharpSDK.Infra.csproj
@@ -65,17 +65,14 @@
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NExtends, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NExtends.1.0.3\lib\net451\NExtends.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NExtends, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NExtends.1.0.11\lib\net451\NExtends.dll</HintPath>
     </Reference>
     <Reference Include="RDD.Domain, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RDD.Domain.1.0.10.1\lib\net451\RDD.Domain.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\RDD.Domain.1.1.3\lib\net461\RDD.Domain.dll</HintPath>
     </Reference>
     <Reference Include="RDD.Infra, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RDD.Infra.1.0.10.1\lib\net451\RDD.Infra.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\RDD.Infra.1.1.3\lib\net461\RDD.Infra.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/CSharp/Infra/CSharpSDK.Infra/packages.config
+++ b/CSharp/Infra/CSharpSDK.Infra/packages.config
@@ -8,7 +8,7 @@
   <package id="MongoDB.Driver" version="2.2.3" targetFramework="net461" />
   <package id="MongoDB.Driver.Core" version="2.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net461" />
-  <package id="NExtends" version="1.0.3" targetFramework="net461" />
-  <package id="RDD.Domain" version="1.0.10.1" targetFramework="net461" />
-  <package id="RDD.Infra" version="1.0.10.1" targetFramework="net461" />
+  <package id="NExtends" version="1.0.11" targetFramework="net461" />
+  <package id="RDD.Domain" version="1.1.3" targetFramework="net461" />
+  <package id="RDD.Infra" version="1.1.3" targetFramework="net461" />
 </packages>

--- a/CSharp/Infra/CSharpSDK.Infra/v2/ApiService.cs
+++ b/CSharp/Infra/CSharpSDK.Infra/v2/ApiService.cs
@@ -1,4 +1,6 @@
 ﻿using Lucca.CSharpSDK.Domain;
+using Lucca.CSharpSDK.Infra.Common;
+using Lucca.CSharpSDK.Infra.Extensions;
 using Newtonsoft.Json;
 using RDD.Domain;
 using RDD.Domain.Contexts;
@@ -6,14 +8,8 @@ using RDD.Domain.Exceptions;
 using RDD.Domain.Models.Querying;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Cache;
-using System.Text;
-using System.Threading.Tasks;
-using Lucca.CSharpSDK.Infra.Extensions;
-using System.Collections.Specialized;
-using Lucca.CSharpSDK.Infra.Common;
 
 namespace Lucca.CSharpSDK.Infra.v2
 {
@@ -34,6 +30,11 @@ namespace Lucca.CSharpSDK.Infra.v2
 			{
 				// Disable cache
 				wc.CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore);
+
+				foreach (var key in query.Headers.RawHeaders.AllKeys)
+				{
+					wc.Headers.Add(key, query.Headers.RawHeaders[key]);
+				}
 				wc.Headers.Add("Authorization", String.Format("Lucca {0}={1}", _settings.AuthenticationInfo.Type.ToString().ToLower(), _settings.AuthenticationInfo.Token));
 
 				var logger = Resolver.Current().Resolve<ILogService>();
@@ -75,12 +76,23 @@ namespace Lucca.CSharpSDK.Infra.v2
 
 		public IEnumerable<TEntity> GetAll()
 		{
-			return Get(new Query<TEntity>());
+			return GetAll(new Query<TEntity>());
 		}
 
-		public TEntity GetById(string uri) { throw new NotImplementedException(); }
-		public TEntity Post(TEntity entity) { throw new NotImplementedException(); }
+		public IEnumerable<TEntity> GetAll(Query<TEntity> query)
+		{
+			return Get(query);
+		}
+
+		public TEntity GetById(string uri) { return GetById(uri, new Query<TEntity>()); }
+		public TEntity GetById(string uri, Query<TEntity> query) { throw new NotImplementedException(); }
+
+		public TEntity Post(TEntity entity) { return Post(entity, new Query<TEntity>()); }
+		public TEntity Post(TEntity entity, Query<TEntity> query) { throw new NotImplementedException(); }
+
 		public IDownloadableEntity PostFile(string uri, string filePath) { throw new NotImplementedException(); }
-		public TEntity Put(string uri, TEntity entity) { throw new NotImplementedException(); }
+
+		public TEntity Put(string uri, TEntity entity) { return Put(uri, entity, new Query<TEntity>()); }
+		public TEntity Put(string uri, TEntity entity, Query<TEntity> query) { throw new NotImplementedException(); }
 	}
 }


### PR DESCRIPTION
Suite à l'évo RDD acceptant des Headers dans la Query, on en tire parti ici en autorisant pour les calls web (Get / Post / Put...) un paramètre Query<T>.

La query est prise en compte et les headers sont passés au WebClient.