### PR TITLE
moment.duration [fix]

### DIFF
--- a/Typescript/src/api-v3.decorator.ts
+++ b/Typescript/src/api-v3.decorator.ts
@@ -227,7 +227,7 @@ module Api.V3 {
 		}
 		if (moment.isDuration(value)) {
 			let formattedValue: string = "";
-			let days: number = value.days();
+			let days: number = Math.floor(Math.abs(value.asDays()));
 			// Handle negative values
 			if (value.asMilliseconds() < 0) {
 				formattedValue = "-";


### PR DESCRIPTION
Whenever a moment.duration is over a month, days() only returns the extra days (over the set integer number of months). Thus the asDays() method should be used.