### PR TITLE
duration-format [fix] fixes timezone effects

### DIFF
--- a/Typescript/src/api-v3.decorator.ts
+++ b/Typescript/src/api-v3.decorator.ts
@@ -237,7 +237,7 @@ module Api.V3 {
 				formattedValue += days + ".";
 				value = value.subtract(moment.duration(days, "days"));
 			}
-			formattedValue += moment().startOf("day").add(value).format("HH:mm:ss");
+			formattedValue += moment.utc(value.asMilliseconds()).format("HH:mm:ss");
 			return formattedValue;
 		}
 	}


### PR DESCRIPTION
New fix : moment applies timezone offsets when constructing the time part. We now force it to UTC to avoid such behavior.