### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @t8g @GuillaumeNury @lucienbertin


### PR DESCRIPTION
On assigne tous les repos à une BU ou à une guilde. Les repos de guilde doivent avoir un fichier CODEOWNERS
cf

https://rizzoma.com/topic/63b6b06ee99a38bc69a5628aae82882a/0_b_c4f9_bh6m0/

Si l'assignation des CODEOWNERS ne vous convient pas, vous êtes libres de proposer d'autres personnes.

